### PR TITLE
XMP-69: temp fix of password drop on update;

### DIFF
--- a/xampl/ViewModels/UserVM.cs
+++ b/xampl/ViewModels/UserVM.cs
@@ -16,6 +16,8 @@ namespace xampl.ViewModels
 
         public string Source { get; set; } = string.Empty;
 
+        public string PasswordHash { get; set; } = string.Empty;
+
         public ICollection<UserRole> UserRoles {  get; set; } = [];
 
         public List<DocumentVM> Documents { get; set; } = [];

--- a/xampl/Views/Users/Edit.cshtml
+++ b/xampl/Views/Users/Edit.cshtml
@@ -15,6 +15,7 @@
             <input type="hidden" asp-for="Id" />
             <input type="hidden" asp-for="CreatedAt" />
             <input type="hidden" asp-for="Source" />
+            <input type="hidden" asp-for="PasswordHash" />
             <div class="form-group">
                 <label asp-for="Email" class="control-label"></label>
                 <input asp-for="Email" class="form-control" />


### PR DESCRIPTION
On User Update - PasswordHash field was dropped.
Temporary fix it by attaching to form as hidden field.
But created a new story to move PasswordHash into dedicated table (with some other columns as well).